### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ for the root user. Then run
     
     btrbck push myStream root@<host> <remote repo path>
     
-This will transfer all snapshots to the remote host. Please not that for this to work, the root of the file system has 
+This will transfer all snapshots to the remote host. Please note that for this to work, the root of the file system has 
 to be mounted directly. Subvolume mounts do not work for send/receive due to a bug in `btrfs-tools`.
 
 ## Permissions


### PR DESCRIPTION
Small typo. However I do not understand this section. My default btrfs layout is this one:
https://wiki.archlinux.org/index.php/Snapper#Suggested_filesystem_layout

So if the @ subvolume is mounted at / it will not work? Or is this fixed at a special kernel version? I am running 4.4 minimum on all systems.
